### PR TITLE
Changed variable names of second half from line 23 on the google sheet

### DIFF
--- a/bola/bola.ino
+++ b/bola/bola.ino
@@ -63,8 +63,8 @@ unsigned long tvc_prev_time_micros = 0;
 
 
 // TVC Limp Mode (Shutdown)
-const float TVC_MAX_ANGLE_LIMIT = 45.0f;    // Max filtered angle before TVC enters limp mode
-const float TVC_RESET_ANGLE_LIMIT = 35.0f;  // Angle below which TVC can exit limp mode
+constexpr float tvc_max_angle_limit = 45.0f;    // Max filtered angle before TVC enters limp mode
+constexpr float tvc_reset_angle_limit = 35.0f;  // Angle below which TVC can exit limp mode
 bool tvc_in_limp_mode = false;
 
 
@@ -78,18 +78,18 @@ float roll_bias = 0, pitch_bias = 0;
 
 // Bluetooth
 BluetoothSerial SerialBT;
-char btCmd;
-bool launchSequence = false;  // main logic flag
+char bt_Cmd;
+bool launch_sequence = false;  // main logic flag
 
 
 // MoI Consts
-const float I_rocket = 0.002395f;
-const float I_wheel = 0.002051f;
+constexpr float moment_i_rocket = 0.002395f;
+constexpr float moment_i_wheel = 0.002051f;
 
 
 // Motor Constants
-unsigned long lastMotorTime = 0,
-             motorInterval = 1000;  // ms between motor triggers
+unsigned long last_motor_time = 0,
+             motor_interval = 1000;  // ms between motor triggers
 
 
 // --- Helpers ---
@@ -98,12 +98,12 @@ uint32_t usToDuty(int us) {
 }
 
 
-static float lpf(float prev_lpf_val, float current_measurement, float beta) {
- return beta * current_measurement + (1.0f - beta) * prev_lpf_val;
+static float lpf(float prev_lpf_val, float current_raw_measurement, float beta) {
+ return beta * current_raw_measurement + (1.0f - beta) * prev_lpf_val;
 }
 
 
-std::array<std::pair<int, int>, 163> lookupTable = { { { -24, 0 }, { -24, 1 }, { -24, 2 }, { -24, 3 }, { -24, 4 }, { -23, 5 }, { -23, 6 }, { -23, 7 }, { -23, 8 }, { -23, 9 }, { -22, 10 }, { -22, 11 }, { -22, 12 }, { -22, 13 }, { -22, 14 }, { -21, 15 }, { -21, 16 }, { -21, 17 }, { -21, 18 }, { -21, 19 }, { -20, 20 }, { -20, 21 }, { -20, 22 }, { -20, 23 }, { -20, 24 }, { -19, 25 }, { -19, 26 }, { -19, 27 }, { -19, 28 }, { -19, 29 }, { -18, 30 }, { -18, 31 }, { -18, 32 }, { -18, 33 }, { -18, 34 }, { -17, 35 }, { -17, 36 }, { -17, 37 }, { -17, 38 }, { -17, 39 }, { -16, 40 }, { -16, 41 }, { -16, 42 }, { -16, 43 }, { -16, 44 }, { -15, 45 }, { -15, 46 }, { -15, 47 }, { -15, 48 }, { -15, 49 }, { -14, 50 }, { -13, 51 }, { -13, 52 }, { -13, 53 }, { -12, 54 }, { -12, 55 }, { -12, 56 }, { -11, 57 }, { -11, 58 }, { -11, 59 }, { -11, 60 }, { -10, 61 }, { -10, 62 }, { -10, 63 }, { -9, 64 }, { -9, 65 }, { -9, 66 }, { -8, 67 }, { -8, 68 }, { -8, 69 }, { -7, 70 }, { -7, 71 }, { -7, 72 }, { -6, 73 }, { -6, 74 }, { -5, 75 }, { -5, 76 }, { -5, 77 }, { -4, 78 }, { -4, 79 }, { -4, 80 }, { -3, 81 }, { -3, 82 }, { -3, 83 }, { -2, 84 }, { -2, 85 }, { -2, 86 }, { -1, 87 }, { -1, 88 }, { -1, 89 }, { 0, 90 }, { 0, 91 }, { 0, 92 }, { 1, 93 }, { 1, 94 }, { 1, 95 }, { 2, 96 }, { 2, 97 }, { 3, 98 }, { 3, 99 }, { 4, 100 }, { 4, 101 }, { 4, 102 }, { 4, 103 }, { 4, 104 }, { 5, 105 }, { 5, 106 }, { 5, 107 }, { 6, 108 }, { 6, 109 }, { 6, 110 }, { 7, 111 }, { 7, 112 }, { 7, 113 }, { 8, 114 }, { 8, 115 }, { 8, 116 }, { 8, 117 }, { 9, 118 }, { 9, 119 }, { 10, 120 }, { 10, 121 }, { 10, 122 }, { 10, 123 }, { 10, 124 }, { 11, 125 }, { 11, 126 }, { 11, 127 }, { 12, 128 }, { 12, 129 }, { 12, 130 }, { 13, 131 }, { 13, 132 }, { 13, 133 }, { 13, 134 }, { 14, 135 }, { 14, 136 }, { 14, 137 }, { 14, 138 }, { 14, 139 }, { 15, 140 }, { 15, 141 }, { 15, 142 }, { 15, 143 }, { 15, 144 }, { 15, 145 }, { 15, 146 }, { 15, 147 }, { 15, 148 }, { 15, 149 }, { 16, 150 }, { 16, 151 }, { 16, 152 }, { 16, 153 }, { 16, 154 }, { 16, 155 }, { 16, 156 }, { 16, 157 }, { 16, 158 }, { 16, 159 }, { 16, 160 }, { 16, 161 }, { 16, 162 } } };
+std::array<std::pair<int, int>, 163> theta2_4lookup_table = { { { -24, 0 }, { -24, 1 }, { -24, 2 }, { -24, 3 }, { -24, 4 }, { -23, 5 }, { -23, 6 }, { -23, 7 }, { -23, 8 }, { -23, 9 }, { -22, 10 }, { -22, 11 }, { -22, 12 }, { -22, 13 }, { -22, 14 }, { -21, 15 }, { -21, 16 }, { -21, 17 }, { -21, 18 }, { -21, 19 }, { -20, 20 }, { -20, 21 }, { -20, 22 }, { -20, 23 }, { -20, 24 }, { -19, 25 }, { -19, 26 }, { -19, 27 }, { -19, 28 }, { -19, 29 }, { -18, 30 }, { -18, 31 }, { -18, 32 }, { -18, 33 }, { -18, 34 }, { -17, 35 }, { -17, 36 }, { -17, 37 }, { -17, 38 }, { -17, 39 }, { -16, 40 }, { -16, 41 }, { -16, 42 }, { -16, 43 }, { -16, 44 }, { -15, 45 }, { -15, 46 }, { -15, 47 }, { -15, 48 }, { -15, 49 }, { -14, 50 }, { -13, 51 }, { -13, 52 }, { -13, 53 }, { -12, 54 }, { -12, 55 }, { -12, 56 }, { -11, 57 }, { -11, 58 }, { -11, 59 }, { -11, 60 }, { -10, 61 }, { -10, 62 }, { -10, 63 }, { -9, 64 }, { -9, 65 }, { -9, 66 }, { -8, 67 }, { -8, 68 }, { -8, 69 }, { -7, 70 }, { -7, 71 }, { -7, 72 }, { -6, 73 }, { -6, 74 }, { -5, 75 }, { -5, 76 }, { -5, 77 }, { -4, 78 }, { -4, 79 }, { -4, 80 }, { -3, 81 }, { -3, 82 }, { -3, 83 }, { -2, 84 }, { -2, 85 }, { -2, 86 }, { -1, 87 }, { -1, 88 }, { -1, 89 }, { 0, 90 }, { 0, 91 }, { 0, 92 }, { 1, 93 }, { 1, 94 }, { 1, 95 }, { 2, 96 }, { 2, 97 }, { 3, 98 }, { 3, 99 }, { 4, 100 }, { 4, 101 }, { 4, 102 }, { 4, 103 }, { 4, 104 }, { 5, 105 }, { 5, 106 }, { 5, 107 }, { 6, 108 }, { 6, 109 }, { 6, 110 }, { 7, 111 }, { 7, 112 }, { 7, 113 }, { 8, 114 }, { 8, 115 }, { 8, 116 }, { 8, 117 }, { 9, 118 }, { 9, 119 }, { 10, 120 }, { 10, 121 }, { 10, 122 }, { 10, 123 }, { 10, 124 }, { 11, 125 }, { 11, 126 }, { 11, 127 }, { 12, 128 }, { 12, 129 }, { 12, 130 }, { 13, 131 }, { 13, 132 }, { 13, 133 }, { 13, 134 }, { 14, 135 }, { 14, 136 }, { 14, 137 }, { 14, 138 }, { 14, 139 }, { 15, 140 }, { 15, 141 }, { 15, 142 }, { 15, 143 }, { 15, 144 }, { 15, 145 }, { 15, 146 }, { 15, 147 }, { 15, 148 }, { 15, 149 }, { 16, 150 }, { 16, 151 }, { 16, 152 }, { 16, 153 }, { 16, 154 }, { 16, 155 }, { 16, 156 }, { 16, 157 }, { 16, 158 }, { 16, 159 }, { 16, 160 }, { 16, 161 }, { 16, 162 } } };
 
 
 
@@ -119,21 +119,21 @@ int getTheta4(int theta2) {
  } else {
    index = theta2 - offset;
  }
- return lookupTable[index].second;
+ return theta2_4lookup_table[index].second;
 }
 
 
 void handleBT() {
  if (SerialBT.available()) {
-   btCmd = SerialBT.read();
-   switch (btCmd) {
+   bt_Cmd = SerialBT.read();
+   switch (bt_Cmd) {
      case '1':
        Serial.println("BT: start launch sequence");
-       launchSequence = true;
+       launch_sequence = true;
        break;
      case '0':
        Serial.println("BT: stop launch sequence");
-       launchSequence = false;
+       launch_sequence = false;
        break;
    }
  }
@@ -209,9 +209,9 @@ void setup() {
 
  // Calibrate bias axes (vertical stance)
  Serial.println("Calibrating biases... hold sensor vertical");
- const int N = 200;
+ constexpr int num_bias_sample = 200;
  float sum_r = 0, sum_y = 0;
- for(int i=0; i<N; i++){
+ for(int i=0; i< num_bias_sample ; i++){
    // 1) TVC control using DMP Game Rotation Vector
   icm_20948_DMP_data_t dmp_data;
   if (imu.readDMPdataFromFIFO(&dmp_data) == ICM_20948_Stat_Ok && (dmp_data.header & DMP_header_bitmap_Quat6))
@@ -249,8 +249,8 @@ void setup() {
   }
    delay(10);
  }
- roll_bias = sum_r/N;
- pitch_bias  = sum_y/N;
+ roll_bias = sum_r/num_bias_sample;
+ pitch_bias  = sum_y/num_bias_sample;
  Serial.printf("Biases: roll=%.1f°, yaw=%.1f°\n", roll_bias, pitch_bias);
 
  servoX.setPeriodHertz(50);
@@ -288,7 +288,7 @@ void loop() {
  // handleBT();
 
 
- // if (!launchSequence) {
+ // if (!launch_sequence) {
  //   delay(50);
  //   return;
  // }
@@ -333,7 +333,7 @@ if ( (fifoStatus == ICM_20948_Stat_Ok     ||
     current_pitch_lpf = lpf(current_pitch_lpf, current_pitch_raw, LPF_BETA) - pitch_bias;
 
    // ---------- TVC Limp Mode Logic ------------------------------
-   if (!tvc_in_limp_mode && (fabs(current_roll_lpf) > TVC_MAX_ANGLE_LIMIT || fabs(current_pitch_lpf) > TVC_MAX_ANGLE_LIMIT)) {
+   if (!tvc_in_limp_mode && (fabs(current_roll_lpf) > tvc_max_angle_limit || fabs(current_pitch_lpf) > tvc_max_angle_limit)) {
      Serial.println("!!! TVC Entering LIMP MODE: Angle limit exceeded !!!");
      tvc_in_limp_mode = true;
      servoX.write(90);  // Go to neutral
@@ -345,7 +345,7 @@ if ( (fifoStatus == ICM_20948_Stat_Ok     ||
    }
 
 
-   if (tvc_in_limp_mode && fabs(current_roll_lpf) < TVC_RESET_ANGLE_LIMIT && fabs(current_pitch_lpf) < TVC_RESET_ANGLE_LIMIT) {
+   if (tvc_in_limp_mode && fabs(current_roll_lpf) < tvc_reset_angle_limit && fabs(current_pitch_lpf) < TVC_RESET_ANGLE_LIMIT) {
      Serial.println("TVC Exiting LIMP MODE: Angles back in range.");
      tvc_in_limp_mode = false;
      // PID state (integrals, prev_errors) will naturally rebuild on next active PID cycle
@@ -423,7 +423,7 @@ if ( (fifoStatus == ICM_20948_Stat_Ok     ||
 
 
    // — 2) Reaction-wheel linear function —
-   float u = (yawRate * I_rocket) / (I_wheel);
+   float u = (yawRate * moment_i_rocket) / (moment_i_wheel);
    int pulse = constrain(1500 - int(u), 1000, 2000);
    ledcWrite(escPin, usToDuty(pulse));
 
@@ -435,10 +435,10 @@ if ( (fifoStatus == ICM_20948_Stat_Ok     ||
  }
 
 //  fire the 2nd motor
- if ((millis() - lastMotorTime >= trigger_time) && !triggered) {
+ if ((millis() - last_motor_time >= trigger_time) && !triggered) {
    triggered = true;
    triggerMotor();
-   lastMotorTime = loop_start_micros;
+   last_motor_time = loop_start_micros;
    // fire leg actuators
    triggerLegs();
  }


### PR DESCRIPTION
Changed variable names and types to be more in line with GRP style guide and be mroe interpretable. NOTE: This is only half the name changes, Parth will be pushing his changes later.

Changed these old names:
tvc_error_integral
tvc_prev_error
tvc_prev_time_micros
TVC_MAX_ANGLE_LIMIT
TVC_RESET_ANGLE_LIMIT
tvc_in_limp_mode
roll_bias
pitch_bias
btCmd
launchSequence
I_rocket
I_wheel
lastMotorTime
motorInterval
us
prev_lpf_val
current_measurement
beta
lookupTable
theta2
n/a
N
sum_r
sum_y
q0
q1
q2
q3
current_roll_raw
current_pitch_raw
sqrt2_over_2
t0_rll
t1_roll
t2_pitch
loop_start_micros
dmp_data
fifoStatus
current_tvc_micros
dt_tvc
tvc_error[2]
servo_command_angle_calculated
axis
current_rw_micros
dt_rw
yawRate
targetYawRate
u
pulse