### PR TITLE
Fix IMU bias calibration accumulation

### DIFF
--- a/bola/bola.ino
+++ b/bola/bola.ino
@@ -1,5 +1,3 @@
-// === SPI VERSION with TVC + Reaction‐Wheel Control ===
-// Make sure to uncomment "#define ICM_20948_USE_DMP" in ICM_20948_C.h
 #include <SPI.h>
 #include <ESP32Servo.h>
 #include "ICM_20948.h"
@@ -10,48 +8,47 @@
 #include <array>  // added for lookup table
 #include "BluetoothSerial.h"
 
-
 // --- SPI pins for VSPI (default) ---
-contexspr int spi_sclk_pin 18;
-contexspr int miso_pin 19;
-contexspr int mosi_pin 23;
-contexspr int icm20948_cs_pin 5;  // Chip‐select for ICM-20948
+constexpr int spi_sclk_pin 18;
+constexpr int miso_pin 19;
+constexpr int mosi_pin 23;
+constexpr int icm20948_cs_pin 5;  // Chip‐select for ICM-20948
 
 
-contexspr int status_led_pin = 17;
+constexpr int status_led_pin = 17;
 
 // --- Reaction‐wheel ESC on GPIO0 ---
-contexspr int reaction_wheel_pin = 0;
-contexspr int reaction_wheel_freq = 50;  // 50 Hz for typical ESC PWM
-contexspr int reaction_wheel_resolution  = 16;   // 16-bit PWM resolution
+constexpr int reaction_wheel_pin = 0;
+constexpr int reaction_wheel_freq = 50;  // 50 Hz for typical ESC PWM
+constexpr int reaction_wheel_resolution  = 16;   // 16-bit PWM resolution
 
 
 // --- TVC servos on two GPIOs ---
 Servo servoX, servoY;
-contexspr int servo_x_pin = 33;
-contexspr int servo_y_pin = 32;
+constexpr int servo_x_pin = 33;
+constexpr int servo_y_pin = 32;
 
 // Leg Servo
 Servo leg_servo;
-contexspr int leg_servo_pin = 15;
+constexpr int leg_servo_pin = 15;
 bool legs_triggered = false;
 
 int trigger_time;
 
 
 // --- PID constants for reaction wheel (yaw rate) ---
-contexspr float  Kp_rw = 3.3125f, Ki_rw = 0.2f, Kd_rw = 1.3f;
+constexpr float  Kp_rw = 3.3125f, Ki_rw = 0.2f, Kd_rw = 1.3f;
 float prevError_rw = 0.0f, integral_rw = 0.0f;
 unsigned long rw_prev_time_micros  = 0;
 
 
 // --- PID constants for TVC (roll/pitch) ---
-contexspr float Kp_tvc = 1.5f;
-contexspr float Ki_tvc = 0.1f;
-contexspr float Kd_tvc = 0.05f;  // START VERY LOW (e.g., 0.0) AND TUNE UP
-contexspr float tvc_time_step_target = 0.01f;
-contexspr float tvc_deadzone = 1.0f;
-contexspr float lpf_beta = 0.2f;
+constexpr float Kp_tvc = 1.5f;
+constexpr float Ki_tvc = 0.1f;
+constexpr float Kd_tvc = 0.05f;  // START VERY LOW (e.g., 0.0) AND TUNE UP
+constexpr float tvc_time_step_target = 0.01f;
+constexpr float tvc_deadzone = 1.0f;
+constexpr float lpf_beta = 0.2f;
 
 
 // Variables for the LPF-based TVC PID
@@ -70,6 +67,12 @@ bool tvc_in_limp_mode = false;
 
 // --- IMU object ---
 ICM_20948_SPI imu;
+
+// --- IMU data ---
+int16_t acceleration[3];
+float euler_angles[3];
+uint8_t pressure[3];
+uint8_t temperature[3];
 
 
 // --- Bias offsets ---
@@ -92,66 +95,206 @@ unsigned long last_motor_time = 0,
              motor_interval = 1000;  // ms between motor triggers
 
 
-// --- Helpers ---
-uint32_t usToDuty(int us) {
- return (uint32_t)us * ((1UL << reaction_wheel_resolution ) - 1) / 20000;
+//COMMUNICATION FUNCTIONS:
+//void sendTelemetry(){}
+void readIMU() {
+  icm_20948_DMP_data_t dmp_data;
+  if(imu.readDMPDataFromFIFO(&dmp_data) == ICM_20948_Stat_Ok){
+    if(dmp_data.header == DMP_header_bitmap_Accel){
+      acceleration[0] = dmp_data.Raw_Accel.X;
+      acceleration[1] = dmp_data.Raw_Accel.Y;
+      acceleration[2] = dmp_data.Raw_Accel.Z;
+    }
+    else if(dmp_data.header == DMP_header_bitmap_Quat6){
+      double q1 = static_cast<double>(dmp_data.Quat6.Data.Q1) / 1073741824.0;  // X-axis rotation component
+      double q2 = static_cast<double>(dmp_data.Quat6.Data.Q2) / 1073741824.0;  // Y-axis rotation component
+      double q3 = static_cast<double>(dmp_data.Quat6.Data.Q3) / 1073741824.0;  // Z-axis rotation component
+      double q_sum_sq = q1 * q1 + q2 * q2 + q3 * q3;
+      double q0 = (q_sum_sq < 1.0) ? sqrt(1.0 - q_sum_sq) : 0.0;
+
+      //https://ntrs.nasa.gov/api/citations/19770024290/downloads/19770024290.pdf
+      //Explanation on using quaternions to represent 3D Rotations
+
+      float roll = atan2(2*(q0*q1 + q2*q3), 1 - 2*(q1*q1 + q2*q2));
+
+      float pitch_raw = 2 * (q0*q2 - q3*q1);
+      float pitch;
+      if(pitch_raw <= -1){
+        pitch = -M_PI_2;
+      } else if(pitch_raw >= 1){
+        pitch = M_PI_2;
+      } else {
+        pitch = asin(pitch_raw);
+      }
+
+      float yaw = atan2(2 * (q0*q3 + q1*q2), 1 - 2*(q2*q2 + q3*q3));
+
+      euler_angles[0] = roll;
+      euler_angles[1] = pitch;
+      euler_angles[2] = yaw;   
+     }
+    else if(dmp_data.header == DMP_header_bitmap_Pressure){
+      uint8_t raw_barometer_data[6] = dmp_data.Pressure;
+      memcpy(pressure, raw_barometer_data, 3);
+      memcpy(temperature, raw_barometer_data+3, 3);
+    }
+  }
 }
 
 
-static float lpf(float prev_lpf_val, float current_raw_measurement, float beta) {
- return beta * current_raw_measurement + (1.0f - beta) * prev_lpf_val;
+//ACTION FUNCTIONS:
+
+void triggerLegs(){
+    ledcWrite(leg_pin, usToDuty(1500));
 }
-
-
-std::array<std::pair<int, int>, 163> theta2_4lookup_table = { { { -24, 0 }, { -24, 1 }, { -24, 2 }, { -24, 3 }, { -24, 4 }, { -23, 5 }, { -23, 6 }, { -23, 7 }, { -23, 8 }, { -23, 9 }, { -22, 10 }, { -22, 11 }, { -22, 12 }, { -22, 13 }, { -22, 14 }, { -21, 15 }, { -21, 16 }, { -21, 17 }, { -21, 18 }, { -21, 19 }, { -20, 20 }, { -20, 21 }, { -20, 22 }, { -20, 23 }, { -20, 24 }, { -19, 25 }, { -19, 26 }, { -19, 27 }, { -19, 28 }, { -19, 29 }, { -18, 30 }, { -18, 31 }, { -18, 32 }, { -18, 33 }, { -18, 34 }, { -17, 35 }, { -17, 36 }, { -17, 37 }, { -17, 38 }, { -17, 39 }, { -16, 40 }, { -16, 41 }, { -16, 42 }, { -16, 43 }, { -16, 44 }, { -15, 45 }, { -15, 46 }, { -15, 47 }, { -15, 48 }, { -15, 49 }, { -14, 50 }, { -13, 51 }, { -13, 52 }, { -13, 53 }, { -12, 54 }, { -12, 55 }, { -12, 56 }, { -11, 57 }, { -11, 58 }, { -11, 59 }, { -11, 60 }, { -10, 61 }, { -10, 62 }, { -10, 63 }, { -9, 64 }, { -9, 65 }, { -9, 66 }, { -8, 67 }, { -8, 68 }, { -8, 69 }, { -7, 70 }, { -7, 71 }, { -7, 72 }, { -6, 73 }, { -6, 74 }, { -5, 75 }, { -5, 76 }, { -5, 77 }, { -4, 78 }, { -4, 79 }, { -4, 80 }, { -3, 81 }, { -3, 82 }, { -3, 83 }, { -2, 84 }, { -2, 85 }, { -2, 86 }, { -1, 87 }, { -1, 88 }, { -1, 89 }, { 0, 90 }, { 0, 91 }, { 0, 92 }, { 1, 93 }, { 1, 94 }, { 1, 95 }, { 2, 96 }, { 2, 97 }, { 3, 98 }, { 3, 99 }, { 4, 100 }, { 4, 101 }, { 4, 102 }, { 4, 103 }, { 4, 104 }, { 5, 105 }, { 5, 106 }, { 5, 107 }, { 6, 108 }, { 6, 109 }, { 6, 110 }, { 7, 111 }, { 7, 112 }, { 7, 113 }, { 8, 114 }, { 8, 115 }, { 8, 116 }, { 8, 117 }, { 9, 118 }, { 9, 119 }, { 10, 120 }, { 10, 121 }, { 10, 122 }, { 10, 123 }, { 10, 124 }, { 11, 125 }, { 11, 126 }, { 11, 127 }, { 12, 128 }, { 12, 129 }, { 12, 130 }, { 13, 131 }, { 13, 132 }, { 13, 133 }, { 13, 134 }, { 14, 135 }, { 14, 136 }, { 14, 137 }, { 14, 138 }, { 14, 139 }, { 15, 140 }, { 15, 141 }, { 15, 142 }, { 15, 143 }, { 15, 144 }, { 15, 145 }, { 15, 146 }, { 15, 147 }, { 15, 148 }, { 15, 149 }, { 16, 150 }, { 16, 151 }, { 16, 152 }, { 16, 153 }, { 16, 154 }, { 16, 155 }, { 16, 156 }, { 16, 157 }, { 16, 158 }, { 16, 159 }, { 16, 160 }, { 16, 161 }, { 16, 162 } } };
-
-
-
-
-//right now 70 degrees is index 0 in the lookup table (can shift offset if needed)
-int getTheta4(int theta2) {
- int offset = 70;
- int index;
- if (theta2 > 110) {
-   index = 110 - offset;
- } else if (theta2 < 70) {
-   index = 70 - offset;
- } else {
-   index = theta2 - offset;
- }
- return theta2_4lookup_table[index].second;
-}
-
-
-void handleBT() {
- if (SerialBT.available()) {
-   bt_Cmd = SerialBT.read();
-   switch (bt_Cmd) {
-     case '1':
-       Serial.println("BT: start launch sequence");
-       launch_sequence = true;
-       break;
-     case '0':
-       Serial.println("BT: stop launch sequence");
-       launch_sequence = false;
-       break;
-   }
- }
-}
-
-
-void triggerMotor() {
- // e.g. ledcWrite(reaction_wheel_pin, usToDuty(2000));
+void triggerMotor(){
+  // e.g. ledcWrite(reaction_wheel_pin, usToDuty(2000));
  Serial.println("Trigger motor and legs");
 }
+void tvcCycle(){
+    // 1) TVC control using DMP Game Rotation Vector
+ icm_20948_DMP_data_t dmp_data;
+ 
+ ICM_20948_Status_e fifoStatus = imu.readDMPdataFromFIFO(&dmp_data);
+
+if ( (fifoStatus == ICM_20948_Stat_Ok     || 
+      fifoStatus == ICM_20948_Stat_FIFOMoreDataAvail) &&
+     (dmp_data.header & DMP_header_bitmap_Quat6) )
+{
+   double q1 = static_cast<double>(dmp_data.Quat6.Data.Q1) / 1073741824.0;  // X-axis rotation component
+   double q2 = static_cast<double>(dmp_data.Quat6.Data.Q2) / 1073741824.0;  // Y-axis rotation component
+   double q3 = static_cast<double>(dmp_data.Quat6.Data.Q3) / 1073741824.0;  // Z-axis rotation component
 
 
-void triggerLegs() {
-  ledcWrite(leg_servo_pin, usToDuty(1500));
+   double q_sum_sq = q1 * q1 + q2 * q2 + q3 * q3;
+   double q0 = (q_sum_sq < 1.0) ? sqrt(1.0 - q_sum_sq) : 0.0;
+
+
+   // ---- CHOOSE AND USE ONLY ONE EULER ANGLE CONVERSION ----
+   // Standard Euler Angle Convention (Confirm your IMU axis mapping to Roll/Pitch vehicle axes)
+   // Roll (around IMU X-axis / vehicle's longitudinal axis)
+   double t0_roll = 2.0 * (q0 * q1 + q2 * q3);
+   double t1_roll = 1.0 - 2.0 * (q1 * q1 + q2 * q2);
+   float current_roll_raw = atan2(t0_roll, t1_roll) * (180.0 / PI) + 90;
+
+
+   // Pitch (around IMU Y-axis)
+    double t2_pitch = (2.0 * (q0 * q2 - q3 * q1))*-1.0;
+    t2_pitch = constrain(t2_pitch, -1.0, 1.0);
+    float current_pitch_raw = asin(t2_pitch) * (180.0 / PI);
+    // ---- END OF EULER ANGLE CONVERSION ----
+
+    current_roll_lpf = lpf(current_roll_lpf, current_roll_raw, LPF_BETA) - roll_bias;
+    current_pitch_lpf = lpf(current_pitch_lpf, current_pitch_raw, LPF_BETA) - pitch_bias;
+
+   // ---------- TVC Limp Mode Logic ------------------------------
+   if (!tvc_in_limp_mode && (fabs(current_roll_lpf) > TVC_MAX_ANGLE_LIMIT || fabs(current_pitch_lpf) > TVC_MAX_ANGLE_LIMIT)) {
+     Serial.println("!!! TVC Entering LIMP MODE: Angle limit exceeded !!!");
+     tvc_in_limp_mode = true;
+     servoX.write(90);  // Go to neutral
+     servoY.write(90);
+     tvc_error_integral[0] = 0.0f;  // Reset PID state
+     tvc_error_integral[1] = 0.0f;
+     tvc_prev_error[0] = 0.0f;  // Reset previous error for D term
+     tvc_prev_error[1] = 0.0f;
+   }
+
+
+   if (tvc_in_limp_mode && fabs(current_roll_lpf) < TVC_RESET_ANGLE_LIMIT && fabs(current_pitch_lpf) < TVC_RESET_ANGLE_LIMIT) {
+     Serial.println("TVC Exiting LIMP MODE: Angles back in range.");
+     tvc_in_limp_mode = false;
+     // PID state (integrals, prev_errors) will naturally rebuild on next active PID cycle
+   }
+
+
+   // --- TVC PID Control ---
+   if (!tvc_in_limp_mode) {
+     unsigned long current_tvc_micros = micros();
+     float dt_tvc = (tvc_prev_time_micros == 0) ? TVC_TIME_STEP_TARGET : static_cast<float>(current_tvc_micros - tvc_prev_time_micros) * 1e-6f;
+     if (dt_tvc <= 0.00001f) { dt_tvc = TVC_TIME_STEP_TARGET; }
+     tvc_prev_time_micros = current_tvc_micros;
+
+
+     float tvc_error[2];
+     tvc_error[0] = 0.0f - current_roll_lpf;
+     tvc_error[1] = 0.0f - current_pitch_lpf;
+
+
+     float servo_command_angle_calculated[2] = { 90.0f, 90.0f };  // Temporary for calculation
+
+
+     for (int axis = 0; axis < 2; ++axis) {
+       if (fabs(tvc_error[axis]) < tvc_deadzone) {
+         servo_command_angle_calculated[axis] = 90.0f;
+         tvc_error_integral[axis] = 0.0f;
+       } else {
+         tvc_error_integral[axis] += tvc_error[axis] * dt_tvc;
+         // Optional: Clamp tvc_error_integral[axis]
+         float derivative = (dt_tvc > 0.00001f) ? (tvc_error[axis] - tvc_prev_error[axis]) / dt_tvc : 0.0f;
+         float pid_correction = Kp_tvc * tvc_error[axis] + Ki_tvc * tvc_error_integral[axis] + Kd_tvc * derivative;
+         float max_deflection = 30.0f;
+         pid_correction = constrain(pid_correction, -max_deflection, max_deflection);
+         servo_command_angle_calculated[axis] = 90.0f + round(pid_correction);
+       }
+       tvc_prev_error[axis] = tvc_error[axis];
+     }
+     servoX.write(static_cast<int>(servo_command_angle_calculated[0]));
+     servoY.write(static_cast<int>(servo_command_angle_calculated[1]));
+
+
+     Serial.print("ACTIVE Roll: ");
+     Serial.print(current_roll_lpf, 1);
+     Serial.print(", Pitch: ");
+     Serial.print(current_pitch_lpf, 1);
+     Serial.print(" | ServoX: ");
+     Serial.print(servo_command_angle_calculated[0], 1);
+     Serial.print(", ServoY: ");
+     Serial.println(servo_command_angle_calculated[1], 1);
+
+
+   } else {  // TVC is in LIMP MODE
+     // Servos should already be at 90 from when limp mode was entered.
+     // This block ensures they stay there if no other logic writes to them.
+     servoX.write(90);
+     servoY.write(90);
+     Serial.print("LIMP MODE Roll: ");
+     Serial.print(current_roll_lpf, 1);
+     Serial.print(", Pitch: ");
+     Serial.print(current_pitch_lpf, 1);
+     Serial.println(" | Servos at Neutral.");
+   }
+ }  // End of DMP data processing
+
+}
+void reactionWheelCycle(){
+    // Consider if reaction wheel should also be affected by tvc_in_limp_mode
+ if (!tvc_in_limp_mode && imu.dataReady()) {  // Only run RW PID if TVC is not in limp mode
+   imu.getAGMT();
+   float yawRate = imu.gyrZ();
+   float targetYawRate = 0.0f;
+   unsigned long current_rw_micros = micros();
+   float dt_rw = (prevTime_rw_micros == 0) ? TVC_TIME_STEP_TARGET : static_cast<float>(current_rw_micros - prevTime_rw_micros) * 1e-6f;
+   if (dt_rw <= 0.00001f) { dt_rw = TVC_TIME_STEP_TARGET; }
+
+   current_yaw_lpf = lpf(current_yaw_lpf, yawRate, LPF_BETA);
+   rw_derivative = (current_yaw_lpf - past_yaw_lfp) / dt_rw;
+   rw_error_integral += (current_yaw_lpf + past_yaw_lfp) * dt_rw;
+   past_yaw_lfp = current_yaw_lpf;
+
+   // — 2) Reaction-wheel PID function —
+   float u = Kp_rw*current_yaw_lpf + Ki_rw*rw_error_integral + Kd_rw*rw_derivative;  // negative of the current yaw direction 
+   int pulse = constrain(1500 - int(u), 1000, 2000);
+   ledcWrite(reaction_wheel_pin, usToDuty(pulse));
+
+
+ } else if (tvc_in_limp_mode) {
+   // If TVC is in limp mode, set reaction wheel to neutral for safety
+   ledcWrite(reaction_wheel_pin, usToDuty(1500));
+   // Serial.println("Reaction Wheel Neutral due to TVC Limp Mode.");
+ }
 }
 
 
-// --- Setup ---
 void setup() {
   pinMode( status_led_pin, OUTPUT); // Set GPIO 17 as an output pin
 
@@ -279,177 +422,112 @@ void setup() {
  Serial.println("Setup complete.");
 }
 
+float prevAltitude = 0;
+float velocity = 0;
+unsigned long lastAltitudeTime = 0;
 
-// --- Main loop ---
+float getAltitude() {
+    // return converted pressure data OR test constant for dummy; placeholder below:
+    return (float)pressure[0]; // FIX later
+}
+
+
 void loop() {
-  
-  digitalWrite( status_led_pin, LOW); // Force GPIO 17 to LOW // Optional: Add a delay (e.g., 1 second)
 
- // handleBT();
+    static int stage = 0;
+    static unsigned long burn1Start = 0;
+    static float apogeeAltitude = 0;
+    static unsigned long apogeeDetectedTime = 0;
+    static bool burn2Triggered = false;
 
+    // Read IMU always
+    readIMU();
 
- // if (!launch_sequence) {
- //   delay(50);
- //   return;
- // }
+    // ------- UPDATE ALTITUDE + VELOCITY ------
+    unsigned long tNow = millis();
+    static unsigned long lastAltitudeTime = millis();
+    float dt = (tNow - lastAltitudeTime) / 1000.0f;
+    float altitude = getAltitude();
+    static float prevAltitude = altitude;
+    static float velocity = 0;
 
+    if(dt > 0.02f) {
+        velocity = (altitude - prevAltitude) / dt;
+        prevAltitude = altitude;
+        lastAltitudeTime = tNow;
+    }
 
- unsigned long loop_start_micros = micros();
+    // -------- STATE MACHINE --------
 
+    switch(stage) {
 
- // 1) TVC control using DMP Game Rotation Vector
- icm_20948_DMP_data_t dmp_data;
- 
- ICM_20948_Status_e fifoStatus = imu.readDMPdataFromFIFO(&dmp_data);
-
-if ( (fifoStatus == ICM_20948_Stat_Ok     || 
-      fifoStatus == ICM_20948_Stat_FIFOMoreDataAvail) &&
-     (dmp_data.header & DMP_header_bitmap_Quat6) )
-{
-   double q1 = static_cast<double>(dmp_data.Quat6.Data.Q1) / 1073741824.0;  // X-axis rotation component
-   double q2 = static_cast<double>(dmp_data.Quat6.Data.Q2) / 1073741824.0;  // Y-axis rotation component
-   double q3 = static_cast<double>(dmp_data.Quat6.Data.Q3) / 1073741824.0;  // Z-axis rotation component
-
-
-   double q_sum_sq = q1 * q1 + q2 * q2 + q3 * q3;
-   double q0 = (q_sum_sq < 1.0) ? sqrt(1.0 - q_sum_sq) : 0.0;
-
-
-   // ---- CHOOSE AND USE ONLY ONE EULER ANGLE CONVERSION ----
-   // Standard Euler Angle Convention (Confirm your IMU axis mapping to Roll/Pitch vehicle axes)
-   // Roll (around IMU X-axis / vehicle's longitudinal axis)
-   double t0_roll = 2.0 * (q0 * q1 + q2 * q3);
-   double t1_roll = 1.0 - 2.0 * (q1 * q1 + q2 * q2);
-   float current_roll_raw = atan2(t0_roll, t1_roll) * (180.0 / PI) + 90;
+        case 0: // Pre-launch
+            // Wait for a command or automatically start Burn 1
+            Serial.println("Stage 0: Awaiting launch...");
+            burn1Start = millis();
+            stage = 1; 
+        break;
 
 
-   // Pitch (around IMU Y-axis)
-    double t2_pitch = (2.0 * (q0 * q2 - q3 * q1))*-1.0;
-    t2_pitch = constrain(t2_pitch, -1.0, 1.0);
-    float current_pitch_raw = asin(t2_pitch) * (180.0 / PI);
-    // ---- END OF EULER ANGLE CONVERSION ----
+        case 1: // BURN 1 ACTIVE (~3.5 sec)
+            tvcCycle();    
+            Serial.println("Stage 1: Burn 1 running...");
 
-    current_roll_lpf = lpf(current_roll_lpf, current_roll_raw, lpf_beta) - roll_bias;
-    current_pitch_lpf = lpf(current_pitch_lpf, current_pitch_raw, lpf_beta) - pitch_bias;
-
-   // ---------- TVC Limp Mode Logic ------------------------------
-   if (!tvc_in_limp_mode && (fabs(current_roll_lpf) > tvc_max_angle_limit || fabs(current_pitch_lpf) > tvc_max_angle_limit)) {
-     Serial.println("!!! TVC Entering LIMP MODE: Angle limit exceeded !!!");
-     tvc_in_limp_mode = true;
-     servoX.write(90);  // Go to neutral
-     servoY.write(90);
-     tvc_error_integral[0] = 0.0f;  // Reset PID state
-     tvc_error_integral[1] = 0.0f;
-     tvc_prev_error[0] = 0.0f;  // Reset previous error for D term
-     tvc_prev_error[1] = 0.0f;
-   }
+            if(millis() - burn1Start >= 3500) {  // 3.5 sec burn
+                Serial.println("Burn 1 complete.");
+                stage = 2;
+            }
+        break;
 
 
-   if (tvc_in_limp_mode && fabs(current_roll_lpf) < tvc_reset_angle_limit && fabs(current_pitch_lpf) < TVC_RESET_ANGLE_LIMIT) {
-     Serial.println("TVC Exiting LIMP MODE: Angles back in range.");
-     tvc_in_limp_mode = false;
-     // PID state (integrals, prev_errors) will naturally rebuild on next active PID cycle
-   }
+        case 2: // COAST PHASE - Detect Apogee (velocity crosses zero downward)
+            Serial.println("Stage 2: Coasting, detecting apogee...");
+
+            if(velocity < 0) {  
+                apogeeAltitude = altitude;
+                apogeeDetectedTime = millis();
+                Serial.printf("Apogee found at %.2fm\n", apogeeAltitude);
+                stage = 3;
+            }
+        break;
 
 
-   // --- TVC PID Control ---
-   if (!tvc_in_limp_mode) {
-     unsigned long current_tvc_micros = micros();
-     float dt_tvc = (tvc_prev_time_micros == 0) ? tvc_time_step_target : static_cast<float>(current_tvc_micros - tvc_prev_time_micros) * 1e-6f;
-     if (dt_tvc <= 0.00001f) { dt_tvc = tvc_time_step_target; }
-     tvc_prev_time_micros = current_tvc_micros;
+        case 3: // COMPUTE WAIT TIME FOR SECOND BURN
+            Serial.println("Stage 3: Calculating timing for burn 2...");
+
+            // *** Placeholder physics: replace with algorithm ***
+            unsigned long burn2Delay = 2000;  // Example: fire 2 seconds after apogee
+
+            if(millis() - apogeeDetectedTime >= burn2Delay) {
+                Serial.println("Firing second burn...");
+                burn2Triggered = true;
+                stage = 4;
+            }
+        break;
 
 
-     float tvc_error[2];
-     tvc_error[0] = 0.0f - current_roll_lpf;
-     tvc_error[1] = 0.0f - current_pitch_lpf;
+        case 4: // SECOND BURN ACTIVE (TVC ON)
+            tvcCycle();
+            Serial.println("Stage 4: Burn 2 active...");
+
+            // Optional: burn until certain velocity/altitude but for now fixed:
+            if(altitude <= 20) { // Arbitrary condition or timer
+                Serial.println("Burn 2 complete, entering landing mode.");
+                stage = 5;
+            }
+        break;
 
 
-     float servo_command_angle_calculated[2] = { 90.0f, 90.0f };  // Temporary for calculation
+        case 5: // LANDING MODE
+            Serial.println("Stage 5: Landing mode...");
 
+            if(altitude <= 3 && !legs_triggered) {
+                Serial.println("Deploying legs...");
+                triggerLegs();
+                legs_triggered = true;
+            }
+        break;
+    }
 
-     for (int axis = 0; axis < 2; ++axis) {
-       if (fabs(tvc_error[axis]) < tvc_deadzone) {
-         servo_command_angle_calculated[axis] = 90.0f;
-         tvc_error_integral[axis] = 0.0f;
-       } else {
-         tvc_error_integral[axis] += tvc_error[axis] * dt_tvc;
-         // Optional: Clamp tvc_error_integral[axis]
-         float derivative = (dt_tvc > 0.00001f) ? (tvc_error[axis] - tvc_prev_error[axis]) / dt_tvc : 0.0f;
-         float pid_correction = Kp_tvc * tvc_error[axis] + Ki_tvc * tvc_error_integral[axis] + Kd_tvc * derivative;
-         float max_deflection = 30.0f;
-         pid_correction = constrain(pid_correction, -max_deflection, max_deflection);
-         servo_command_angle_calculated[axis] = 90.0f + round(pid_correction);
-       }
-       tvc_prev_error[axis] = tvc_error[axis];
-     }
-     servoX.write(static_cast<int>(servo_command_angle_calculated[0]));
-     servoY.write(static_cast<int>(servo_command_angle_calculated[1]));
-
-
-     Serial.print("ACTIVE Roll: ");
-     Serial.print(current_roll_lpf, 1);
-     Serial.print(", Pitch: ");
-     Serial.print(current_pitch_lpf, 1);
-     Serial.print(" | ServoX: ");
-     Serial.print(servo_command_angle_calculated[0], 1);
-     Serial.print(", ServoY: ");
-     Serial.println(servo_command_angle_calculated[1], 1);
-
-
-   } else {  // TVC is in LIMP MODE
-     // Servos should already be at 90 from when limp mode was entered.
-     // This block ensures they stay there if no other logic writes to them.
-     servoX.write(90);
-     servoY.write(90);
-     Serial.print("LIMP MODE Roll: ");
-     Serial.print(current_roll_lpf, 1);
-     Serial.print(", Pitch: ");
-     Serial.print(current_pitch_lpf, 1);
-     Serial.println(" | Servos at Neutral.");
-   }
- }  // End of DMP data processing
-
-
- // 2) Reaction-wheel Controller
- // Consider if reaction wheel should also be affected by tvc_in_limp_mode
- if (!tvc_in_limp_mode && imu.dataReady()) {  // Only run RW PID if TVC is not in limp mode
-   imu.getAGMT();
-   float yawRate = imu.gyrZ();
-   float targetYawRate = 0.0f;
-   unsigned long current_rw_micros = micros();
-   float dt_rw = (rw_prev_time_micros  == 0) ? tvc_time_step_target : static_cast<float>(current_rw_micros - rw_prev_time_micros ) * 1e-6f;
-   if (dt_rw <= 0.00001f) { dt_rw = tvc_time_step_target; }
-
-
-   // — 2) Reaction-wheel linear function —
-   float u = (yawRate * moment_i_rocket) / (moment_i_wheel);
-   int pulse = constrain(1500 - int(u), 1000, 2000);
-   ledcWrite(reaction_wheel_pin, usToDuty(pulse));
-
-
- } else if (tvc_in_limp_mode) {
-   // If TVC is in limp mode, set reaction wheel to neutral for safety
-   ledcWrite(reaction_wheel_pin, usToDuty(1500));
-   // Serial.println("Reaction Wheel Neutral due to TVC Limp Mode.");
- }
-
-//  fire the 2nd motor
- if ((millis() - last_motor_time >= trigger_time) && !legs_triggered) {
-   legs_triggered = true;
-   triggerMotor();
-   last_motor_time = loop_start_micros;
-   // fire leg actuators
-   triggerLegs();
- }
-
-
-
-
- // --- Maintain loop rate ---
-//  long loop_duration_micros = micros() - loop_start_micros;
-//  long delay_needed_micros = static_cast<long>(tvc_time_step_target * 1e6f) - loop_duration_micros;
-//  if (delay_needed_micros > 0) {
-//    delayMicroseconds(delay_needed_micros);
-//  }
+    delay(10);
 }

--- a/bola/bola.ino
+++ b/bola/bola.ino
@@ -389,6 +389,9 @@ void setup() {
 
     current_roll_lpf = lpf(current_roll_lpf, current_roll_raw, lpf_beta);
     current_pitch_lpf = lpf(current_pitch_lpf, current_pitch_raw, lpf_beta);
+
+    sum_r += current_roll_lpf;
+    sum_y += current_pitch_lpf;
   }
    delay(10);
  }


### PR DESCRIPTION
Fixes a bug where roll and pitch bias were always zero because filtered IMU values
were never accumulated during calibration.

This adds `sum_r` and `sum_y` accumulation so `roll_bias` and `pitch_bias`
reflect the actual sensor orientation.